### PR TITLE
Add add-on ID to enable installing on Firefox Developer Edition

### DIFF
--- a/Extension/manifest.json
+++ b/Extension/manifest.json
@@ -109,7 +109,11 @@
 		"tabs", 
 		"<all_urls>"
 		
-	]
-	
+	],
+	"applications": {
+		"gecko": {
+			"id": "grabanymedia@altervista.org"
+		}
+	}
 }
 


### PR DESCRIPTION
According to the [documentation](https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/#When_do_you_need_an_Add-on_ID), "If you are loading the add-on from its XPI file, are not loading it temporarily using about:debugging and **it is not signed**", the add-on ID is required. 

